### PR TITLE
Feature: Add Docker Support and HTTP Transport Option

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,50 @@
+name: Build and Push Docker Image to GHCR
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'  # Trigger on version tags like v1.0.0, v2.1.3, etc.
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write  # Required for pushing to GHCR
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/ticktick-mcp
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Dockerfile for TickTick MCP Server (FastMCP, streamable-http)
+FROM python:3.10-slim
+
+# Install uv and copy project files
+RUN pip install uv
+COPY . /app
+WORKDIR /app
+
+# Create a virtual environment
+RUN uv venv .
+
+# Install dependencies using uv
+RUN uv pip install -e .
+
+# Expose the default FastMCP HTTP port
+EXPOSE 8000
+
+# Start the MCP server with streamable-http transport (default host/port)
+CMD ["uv", "run", "-m", "ticktick_mcp.cli", "run", "--transport", "streamable-http"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN uv pip install -e .
 EXPOSE 8000
 
 # Start the MCP server with streamable-http transport (default host/port)
-CMD ["uv", "run", "-m", "ticktick_mcp.cli", "run", "--transport", "streamable-http"]
+CMD ["uv", "run", "-m", "ticktick_mcp.cli", "run", "--transport", "streamable-http", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,20 @@ RUN uv venv .
 # Install dependencies using uv
 RUN uv pip install -e .
 
+# Create startup scripts for different modes
+RUN echo '#!/bin/sh\n\
+    uv run -m ticktick_mcp.cli auth\n\
+    uv run -m ticktick_mcp.cli run --transport streamable-http --host 0.0.0.0 --port 8000\n\
+    ' > /usr/local/bin/run-with-auth && \
+    chmod +x /usr/local/bin/run-with-auth
+
+RUN echo '#!/bin/sh\n\
+    uv run -m ticktick_mcp.cli run --transport streamable-http --host 0.0.0.0 --port 8000\n\
+    ' > /usr/local/bin/run-production && \
+    chmod +x /usr/local/bin/run-production
+
 # Expose the default FastMCP HTTP port
 EXPOSE 8000
 
-# Start the MCP server with streamable-http transport (default host/port)
-CMD ["uv", "run", "-m", "ticktick_mcp.cli", "run", "--transport", "streamable-http", "--host", "0.0.0.0", "--port", "8000"]
+# Default: Run with authentication flow for interactive setup
+CMD ["/bin/sh", "-c", "run-production"]

--- a/README.md
+++ b/README.md
@@ -131,6 +131,42 @@ The server handles token refresh automatically, so you won't need to reauthentic
 
 Once connected, you'll see the TickTick MCP server tools available in Claude, indicated by the 🔨 (tools) icon.
 
+## Usage with Docker
+
+You can also run the TickTick MCP server in a Docker container for local testing or production deployment:
+
+1. **Build the Docker image:**
+   ```bash
+   docker build -t ticktick-mcp:latest .
+   ```
+
+2. **Run the container:**
+   ```bash
+   docker run -p 8000:8000 --env TICKTICK_CLIENT_ID --env TICKTICK_CLIENT_SECRET --env TICKTICK_ACCESS_TOKEN ticktick-mcp:latest
+   ```
+   - This will start the server on port 8000 using the streamable HTTP transport.
+   - You can also use `--env-file .env` if you have your credentials in a file.
+
+3. **Use the server:**
+   - Send requests to: `http://localhost:8000/`
+   - The MCP endpoints will be available for integration with Claude, n8n, or other MCP clients.
+
+## Deploy locally from source
+
+### Option A: Run as stdio server
+
+```bash
+uv run -m ticktick_mcp.cli run --transport stdio
+```
+This will start the server using the stdio transport, which is suitable for local tools and integrations like Claude Desktop.
+
+### Option B: Run as HTTP server
+
+```bash
+uv run -m ticktick_mcp.cli run --transport streamable-http
+```
+This will start the server using the streamable HTTP transport on the default host and port (`http://localhost:8000/`).
+
 ## Available MCP Tools
 
 | Tool | Description | Parameters |

--- a/README.md
+++ b/README.md
@@ -156,14 +156,57 @@ For when authenticating with TickTick using Docker.
    TICKTICK_CLIENT_SECRET=your_client_secret_here
    ```
 
-2. **Build the Docker image:**
+2. **Get the Docker image** (choose one option):
+
+   **Option A: Pull from GitHub Container Registry (Recommended):**
+   ```bash
+   docker pull ghcr.io/jacepark12/ticktick-mcp:latest
+   ```
+
+   **Option B: Build locally:**
+   First clone the repository if you haven't already
+   ```bash
+   git clone https://github.com/jacepark12/ticktick-mcp.git
+   cd ticktick-mcp
+   ```
+   Then build the image
    ```bash
    docker build -t ticktick-mcp:latest .
    ```
 
 3. **Run the authentication:**
+
+   **If you pulled from GHCR:**
    ```bash
+   docker run -p 8000:8000 -it ghcr.io/jacepark12/ticktick-mcp:latest run-with-auth
+   ```
+
+   **If you built locally:**
+   ```bash
+   docker run -p 8000:8000 -it ticktick-mcp:latest run-with-auth
+   ```
+
+   **Additional options:**
+
+   **Option A: Persistent `.env` file (recommended for saving tokens across runs):**
+   ```bash
+   # With GHCR image
+   docker run -p 8000:8000 -it -v $(pwd)/.env:/app/.env ghcr.io/jacepark12/ticktick-mcp:latest run-with-auth
+   
+   # With local image
    docker run -p 8000:8000 -it -v $(pwd)/.env:/app/.env ticktick-mcp:latest run-with-auth
+   ```
+
+   **Option B: Using environment variables directly:**
+   ```bash
+   # Using -e flags
+   docker run -p 8000:8000 -it \
+     -e TICKTICK_CLIENT_ID="your_client_id" \
+     -e TICKTICK_CLIENT_SECRET="your_client_secret" \
+     ghcr.io/jacepark12/ticktick-mcp:latest run-with-auth
+   
+   # Using --env-file
+   docker run -p 8000:8000 -it --env-file .env ghcr.io/jacepark12/ticktick-mcp:latest run-with-auth
    ```
 
 The container will:
@@ -172,6 +215,8 @@ The container will:
 - Automatically receive the OAuth callback via port mapping
 - Save the access token in the persisted .env file
 - Start the MCP server on `http://localhost:8000` to validate the connection
+
+
 
 4. **Verify .env variables:**
    Once authentication is complete, your `.env` file will contain:
@@ -190,17 +235,38 @@ For production deployments where you already have access tokens:
    ```
    TICKTICK_CLIENT_ID=your_client_id_here
    TICKTICK_CLIENT_SECRET=your_client_secret_here
-   TICKTICK_CLIENT_ACCESS_TOKEN=your_access_token_here
+   TICKTICK_ACCESS_TOKEN=your_access_token_here
+   ```
+   
+   **Note**: You can skip creating this file and provide environment variables directly in step 3 using `-e [ENV_VAR]` flags instead.
+
+2. **Get the Docker image** (choose one option):
+
+   **Option A: Pull from GitHub Container Registry (Recommended):**
+   ```bash
+   docker pull ghcr.io/jacepark12/ticktick-mcp:latest
    ```
 
-2. **Build the Docker image:**
+   **Option B: Build locally:**
    ```bash
+   # First clone the repository if you haven't already
+   git clone https://github.com/jacepark12/ticktick-mcp.git
+   cd ticktick-mcp
+   
+   # Then build the image
    docker build -t ticktick-mcp:latest .
    ```
 
-2. **Run the server directly:**
+3. **Run the server directly:**
+
+   **If you pulled from GHCR:**
    ```bash
-   docker run -p 8000:8000 ticktick-mcp:latest
+   docker run -p 8000:8000 --env-file .env ghcr.io/jacepark12/ticktick-mcp:latest 
+   ```
+
+   **If you built locally:**
+   ```bash
+   docker run -p 8000:8000 --env-file .env ticktick-mcp:latest
    ```
 
 This mode skips authentication and directly starts the server, suitable for:

--- a/test_server_streamable_http.py
+++ b/test_server_streamable_http.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Use uv run test_server.py [host] [port] to run this script
+# Make sure to run the server first with `uv run -m ticktick_mcp.cli --transport streamable-http --host [host] --port [port]`
+"""
+Test script to verify the TickTick MCP server's streamable-http mode.
+Starts the server as a subprocess and checks HTTP connectivity.
+Usage: python test_streamable_http.py [host] [port]
+"""
+
+import sys
+import asyncio
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+import traceback
+
+async def main():
+    host = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1"
+    port = int(sys.argv[2]) if len(sys.argv) > 2 else 8000
+    session_id = sys.argv[3] if len(sys.argv) > 3 else "testsession"
+
+    try:
+        # Connect to a streamable HTTP server
+        async with streamablehttp_client(f"http://{host}:{port}/mcp?session={session_id}") as (
+            read_stream,
+            write_stream,
+            _,
+        ):
+            # Create a session using the client streams
+            async with ClientSession(read_stream, write_stream) as session:
+                # Initialize the connection
+                await session.initialize()
+                # List available tools
+                tools = await session.list_tools()
+                print(f"Available tools: {[tool.name for tool in tools.tools]}")
+                print("\n✅ Success: MCP streamable-http server is reachable and functional!")
+    except Exception as e:
+        print("\n❌ ERROR: An exception occurred while testing the streamable-http server:")
+        print(f"{type(e).__name__}: {e}")
+        traceback.print_exc()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/ticktick_mcp/cli.py
+++ b/ticktick_mcp/cli.py
@@ -37,7 +37,18 @@ def main():
         choices=["stdio", "streamable-http"],
         help="Transport type: 'stdio' (default) or 'streamable-http' for HTTP server"
     )
-    
+    run_parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host to bind the http server to"
+    )
+    run_parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port to bind the http server to"
+    )
+
     # 'auth' command for authentication
     auth_parser = subparsers.add_parser("auth", help="Authenticate with TickTick")
     
@@ -84,7 +95,7 @@ Run 'uv run -m ticktick_mcp.cli auth' to set up authentication later.
             format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
         )
         try:
-            server_main(transport=args.transport)
+            server_main(transport=args.transport, host=args.host, port=args.port)
         except KeyboardInterrupt:
             print("Server stopped by user", file=sys.stderr)
             sys.exit(0)

--- a/ticktick_mcp/cli.py
+++ b/ticktick_mcp/cli.py
@@ -32,10 +32,10 @@ def main():
         help="Enable debug logging"
     )
     run_parser.add_argument(
-        "--transport", 
-        default="stdio", 
-        choices=["stdio"], 
-        help="Transport type (currently only stdio is supported)"
+        "--transport",
+        default="stdio",
+        choices=["stdio", "streamable-http"],
+        help="Transport type: 'stdio' (default) or 'streamable-http' for HTTP server"
     )
     
     # 'auth' command for authentication
@@ -83,10 +83,8 @@ Run 'uv run -m ticktick_mcp.cli auth' to set up authentication later.
             level=log_level,
             format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
         )
-        
-        # Start the server
         try:
-            server_main()
+            server_main(transport=args.transport)
         except KeyboardInterrupt:
             print("Server stopped by user", file=sys.stderr)
             sys.exit(0)

--- a/ticktick_mcp/src/server.py
+++ b/ticktick_mcp/src/server.py
@@ -981,15 +981,15 @@ async def create_subtask(
         logger.error(f"Error in create_subtask: {e}")
         return f"Error creating subtask: {str(e)}"
 
-def main():
+def main(transport='stdio'):
     """Main entry point for the MCP server."""
     # Initialize the TickTick client
     if not initialize_client():
         logger.error("Failed to initialize TickTick client. Please check your API credentials.")
         return
-    
-    # Run the server
-    mcp.run(transport='stdio')
+
+    # Run the server with the selected transport
+    mcp.run(transport=transport)
 
 if __name__ == "__main__":
     main()

--- a/ticktick_mcp/src/server.py
+++ b/ticktick_mcp/src/server.py
@@ -981,15 +981,23 @@ async def create_subtask(
         logger.error(f"Error in create_subtask: {e}")
         return f"Error creating subtask: {str(e)}"
 
-def main(transport='stdio'):
+def main(transport='stdio', host='127.0.0.1', port=8000):
     """Main entry point for the MCP server."""
     # Initialize the TickTick client
     if not initialize_client():
         logger.error("Failed to initialize TickTick client. Please check your API credentials.")
         return
 
-    # Run the server with the selected transport
-    mcp.run(transport=transport)
+    if transport == 'stdio':
+        # Use standard input/output for MCP
+        mcp.run(transport='stdio')
+    elif transport == 'streamable-http':
+        # Use Streamable HTTP transport with specified host and port
+        mcp.settings.host = host
+        mcp.settings.port = port
+        mcp.run(transport='streamable-http')
+
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

This PR introduces Docker support for the TickTick MCP server and enhances the CLI to allow running the server with either `stdio` or `streamable-http` transport. It also updates the documentation to reflect these new capabilities.

### Changes

**Docker Support**
- Added a Dockerfile for building and running the TickTick MCP server in a container.

**HTTP Support**
- Modified the server’s main function to accept the transport type as an argument.
- Updated the CLI to support a new `--transport` option, allowing selection between `stdio` (default) and `streamable-http` for HTTP server mode.


**Documentation**
- Expanded the README.md with instructions for building, running, and using the server with Docker.
- Added usage examples for both stdio and HTTP server modes.

### Motivation

- Simplifies deployment by providing a ready-to-use Docker image.
- Enables running the server as a streamable HTTP service, making it easier to integrate with tools and platforms that require HTTP endpoints.

### Testing

- Built and ran the Docker image locally and as Azure Container App.
- Verified both `stdio` and `streamable-http` transport modes work as expected.
    - added `test_server_streamable_http.py` to test the new transport mode.