### PR TITLE
feat: add tags support to create_task and update_task

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for Ti
 - 📋 View all your TickTick projects and tasks
 - ✏️ Create new projects and tasks through natural language
 - 🔄 Update existing task details (title, content, dates, priority)
+- 🏷️ Add and manage tags on tasks
 - ✅ Mark tasks as complete
 - 🗑️ Delete tasks and projects
 - 🔄 Full integration with TickTick's open API
@@ -139,8 +140,8 @@ Once connected, you'll see the TickTick MCP server tools available in Claude, in
 | `get_project` | Get details about a specific project | `project_id` |
 | `get_project_tasks` | List all tasks in a project | `project_id` |
 | `get_task` | Get details about a specific task | `project_id`, `task_id` |
-| `create_task` | Create a new task | `title`, `project_id`, `content` (optional), `start_date` (optional), `due_date` (optional), `priority` (optional) |
-| `update_task` | Update an existing task | `task_id`, `project_id`, `title` (optional), `content` (optional), `start_date` (optional), `due_date` (optional), `priority` (optional) |
+| `create_task` | Create a new task | `title`, `project_id`, `content` (optional), `start_date` (optional), `due_date` (optional), `priority` (optional), `tags` (optional) |
+| `update_task` | Update an existing task | `task_id`, `project_id`, `title` (optional), `content` (optional), `start_date` (optional), `due_date` (optional), `priority` (optional), `tags` (optional) |
 | `complete_task` | Mark a task as complete | `project_id`, `task_id` |
 | `delete_task` | Delete a task | `project_id`, `task_id` |
 | `create_project` | Create a new project | `name`, `color` (optional), `view_mode` (optional) |
@@ -183,6 +184,12 @@ Here are some example prompts to use with Claude after connecting the TickTick M
 - "Mark the task 'Buy groceries' as complete"
 - "Create a new project called 'Vacation Planning' with a blue color"
 - "When is my next deadline in TickTick?"
+
+### Tags
+
+- "Create a task 'Read paper on transformers' with tags: learning, AI"
+- "Add the tag 'urgent' to my task about the project deadline"
+- "Create a shopping task and tag it as 'errands' and 'weekend'"
 
 ### Task Filtering Queries
 

--- a/ticktick_mcp/src/server.py
+++ b/ticktick_mcp/src/server.py
@@ -83,6 +83,10 @@ def format_task(task: Dict) -> str:
         for i, item in enumerate(items, 1):
             status = "✓" if item.get('status') == 1 else "□"
             formatted += f"{i}. [{status}] {item.get('title', 'No title')}\n"
+
+    # Add tags if available
+    if task.get('tags'):
+        formatted += f"Tags: {', '.join(task.get('tags'))}\n"
     
     return formatted
 
@@ -218,7 +222,8 @@ async def create_task(
     content: str = None, 
     start_date: str = None, 
     due_date: str = None, 
-    priority: int = 0
+    priority: int = 0,
+    tags: list = None
 ) -> str:
     """
     Create a new task in TickTick.
@@ -230,6 +235,7 @@ async def create_task(
         start_date: Start date in ISO format YYYY-MM-DDThh:mm:ss+0000 (optional)
         due_date: Due date in ISO format YYYY-MM-DDThh:mm:ss+0000 (optional)
         priority: Priority level (0: None, 1: Low, 3: Medium, 5: High) (optional)
+        tags: List of tags to add to the task (optional) e.g. ["work", "urgent"]
     """
     if not ticktick:
         if not initialize_client():
@@ -255,7 +261,8 @@ async def create_task(
             content=content,
             start_date=start_date,
             due_date=due_date,
-            priority=priority
+            priority=priority,
+            tags=tags
         )
         
         if 'error' in task:
@@ -274,7 +281,8 @@ async def update_task(
     content: str = None,
     start_date: str = None,
     due_date: str = None,
-    priority: int = None
+    priority: int = None,
+    tags: list = None
 ) -> str:
     """
     Update an existing task in TickTick.
@@ -287,6 +295,7 @@ async def update_task(
         start_date: New start date in ISO format YYYY-MM-DDThh:mm:ss+0000 (optional)
         due_date: New due date in ISO format YYYY-MM-DDThh:mm:ss+0000 (optional)
         priority: New priority level (0: None, 1: Low, 3: Medium, 5: High) (optional)
+        tags: List of tags to add to the task (optional) e.g. ["work", "urgent"]
     """
     if not ticktick:
         if not initialize_client():
@@ -313,7 +322,8 @@ async def update_task(
             content=content,
             start_date=start_date,
             due_date=due_date,
-            priority=priority
+            priority=priority,
+            tags=tags
         )
         
         if 'error' in task:

--- a/ticktick_mcp/src/ticktick_client.py
+++ b/ticktick_mcp/src/ticktick_client.py
@@ -224,12 +224,12 @@ class TickTickClient:
     
     # Task methods
     def get_task(self, project_id: str, task_id: str) -> Dict:
-        """Gets a specific task by project ID and task ID."""
         return self._make_request("GET", f"/project/{project_id}/task/{task_id}")
     
     def create_task(self, title: str, project_id: str, content: str = None, 
                    start_date: str = None, due_date: str = None, 
-                   priority: int = 0, is_all_day: bool = False) -> Dict:
+                   priority: int = 0, is_all_day: bool = False,
+                    tags: list = None) -> Dict:
         """Creates a new task."""
         data = {
             "title": title,
@@ -246,12 +246,15 @@ class TickTickClient:
             data["priority"] = priority
         if is_all_day is not None:
             data["isAllDay"] = is_all_day
+        if tags:
+            data["tags"] = tags
             
         return self._make_request("POST", "/task", data)
     
     def update_task(self, task_id: str, project_id: str, title: str = None, 
                    content: str = None, priority: int = None, 
-                   start_date: str = None, due_date: str = None) -> Dict:
+                   start_date: str = None, due_date: str = None,
+                    tags : list = None) -> Dict:
         """Updates an existing task."""
         data = {
             "id": task_id,
@@ -268,6 +271,8 @@ class TickTickClient:
             data["startDate"] = start_date
         if due_date:
             data["dueDate"] = due_date
+        if tags:
+            data["tags"] = tags
             
         return self._make_request("POST", f"/task/{task_id}", data)
     


### PR DESCRIPTION
## What this PR does

Adds optional `tags` parameter to `create_task` and `update_task` tools.

TickTick's Open API supports tags on tasks but the original implementation didn't expose this field. This PR adds full tag support.

## Changes

- `ticktick_client.py`: Added `tags: list = None` parameter to `create_task` and `update_task`
- `server.py`: Propagated `tags` parameter through MCP tool definitions and updated docstrings
- `server.py`: `format_task` now displays tags when present
- `README.md`: Updated features list, tool parameters table, and added tag example prompts

## Testing

Tested manually via Claude Desktop MCP integration:
- ✅ Create task with tags
- ✅ Create task without tags (existing behavior unchanged)
- ✅ Update existing task to add tags
